### PR TITLE
Remove xl:max-w-none from <main> tag

### DIFF
--- a/resources/views/layouts/app-docs.blade.php
+++ b/resources/views/layouts/app-docs.blade.php
@@ -117,7 +117,7 @@
         </div>
         <div class="lg:pl-[19.5rem]">
 
-            <main class="max-w-3xl mx-auto relative z-20 pt-10 xl:max-w-none">
+            <main class="max-w-3xl mx-auto relative z-20 pt-10">
                 <div class="prose dark:prose-invert prose-blockquote:bg-slate-400/10 prose-blockquote:p-4 prose-blockquote:rounded-md prose-blockquote:shadow-sm self-center m-auto">
                     @yield('content')
 


### PR DESCRIPTION
Just discovered the project and already like the look of it! Using it on a new app.

One slight issue I discovered with the docs site is that the  xl:max-w-none class on the <main> tag overlaps the side navigation bar, meaning you can't navigate through documents.  This happens on larger screens over the XL breakpoint obviously, when I resized the screen using chrome inspector window I could click links again.

I tested removing the tag in Chrome Developer tools and it didn't affect the main content layout, but did allow me to click on the links again.

Thanks for the hard work and documentation site.  The docs are very comprehensive and great coming from bare flutter workflows!